### PR TITLE
Fix playground compatibility with non-iOS Swift

### DIFF
--- a/MyPlayground.playground/Contents.swift
+++ b/MyPlayground.playground/Contents.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 
 var greeting = "Hello world!"
 print(greeting)


### PR DESCRIPTION
## Summary
- replace UIKit with Foundation so the playground can run on any Swift toolchain

## Testing
- `swift MyPlayground.playground/Contents.swift`
- `swiftc MyPlayground.playground/Contents.swift -o test_program && ./test_program`


------
https://chatgpt.com/codex/tasks/task_e_6842b7e9a9a08324a6f7e2c97aaaf157